### PR TITLE
GV-6 Integrate clang-format to the project.

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,3 @@
+BasedOnStyle: Google
+IndentWidth: 4
+UseTab: Never

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -1,0 +1,25 @@
+name: ClangFormat
+
+on:
+  push:
+    branches: [ main ]
+
+jobs:
+  clang-format:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Install ClangFormat
+      run: sudo apt-get update && sudo apt-get install -y clang-format
+
+    - name: Format code
+      run: find . -name "*.cpp" -o -name "*.hpp" -o -name "*.h" | xargs clang-format -i
+
+    - name: Commit changes
+      run: |
+        git config user.name github-actions
+        git config user.email github-actions@github.com
+        git commit -am "ClangFormat"
+        git push


### PR DESCRIPTION
This PR closes GV-6 ticket.
I have added a `.clang-format` file to the root of the project, which contains the formatting options for clang-format. These options control the way that the code is formatted when `clang-format` is run.

I have also created a `clang-format.yml` file in the `.github/workflows` directory, which sets up a Github Actions workflow that runs `clang-format` on any changes made to the codebase. This workflow will automatically format any changes made to the codebase and commit them back to the repository.

Please note that this formatting will only be applied to changes made after the workflow has been set up. Existing code will not be automatically formatted, but can be manually formatted using `clang-format`.