### PR TITLE
GV-6 integrate clang-format to the project.

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,4 +1,4 @@
-BasedOnStyle: Microsoft
+BasedOnStyle: Google
 IndentWidth: 4
 UseTab: Never
 BreakBeforeBraces: Allman
@@ -7,3 +7,4 @@ SpacesBeforeTrailingComments: 2
 IndentCaseLabels: true
 AllowShortCaseLabelsOnASingleLine: false
 ColumnLimit: 100
+InsertNewlineAtEOF: true

--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,9 @@
+BasedOnStyle: Microsoft
+IndentWidth: 4
+UseTab: Never
+BreakBeforeBraces: Allman
+PointerAlignment: Left
+SpacesBeforeTrailingComments: 2
+IndentCaseLabels: true
+AllowShortCaseLabelsOnASingleLine: false
+ColumnLimit: 100


### PR DESCRIPTION
This PR is closes GV-6 ticket.
I've added a `.clang-format` file to the project, which specifies the code formatting style to be used for C++ files. The format I've chosen is based on the Microsoft style, with a few modifications:

- Indentation is set to 4 spaces.
- Tabs are never used for indentation.
- Braces are placed on a new line for all statements.
- Pointer alignment is set to left.
- Two spaces are added before trailing comments.
- Case labels are indented.
- Short case labels are not allowed on a single line.
- The maximum line width is set to 100 characters.

I've added a pre-commit hook to the project. This hook is designed to automatically format certain files using ClangFormat and add them to the commit.

What this means is that when you run `git commit`, the pre-commit hook will run first and automatically format any files with extensions `.cpp`, `.hpp`, `.h` that are staged for commit. It will then add those changes to the commit.

The idea behind this is to ensure that our code is consistently formatted, which can help with readability and maintainability. It also reduces the likelihood of formatting errors slipping through the cracks.

If you have any questions or concerns, feel free to let me know!