### PR TITLE
GV-7 : Add Google Test as submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "libs/googletest"]
+	path = libs/googletest
+	url = https://github.com/google/googletest.git


### PR DESCRIPTION
this PR closes [GV-7](https://graphviz.atlassian.net/browse/GV-7?atlOrigin=eyJpIjoiMDY3NWE3N2IzNjUxNDU0MzgwMzA3N2JiN2ZiNDI2OTciLCJwIjoiaiJ9) ticket

* to update submodule run `git submodule update --init --recursive`
* Configure your build system to include the Google Test submodule.
```
# Include Google Test as a subdirectory
add_subdirectory(extern/googletest)

# Link the Google Test libraries to your test executable
target_link_libraries(<your_test_executable> gtest gtest_main)
```
* Now, Google Test is integrated into your project as a submodule. When you clone your project, use the --recursive flag to ensure the submodule is also cloned:
`git clone --recursive <your_project_repo_url>`