### PR TITLE
GV-6. integrate clang-format

### DIFF
--- a/tools/pre-commit
+++ b/tools/pre-commit
@@ -1,0 +1,22 @@
+#!/bin/sh
+
+# Redirect output to stderr.
+exec 1>&2
+
+# Check for unstaged changes.
+staged_files=$(git diff --name-only --cached)
+
+if [ -z "$staged_files" ]; then
+  echo "No staged files. Skipping clang-format."
+  exit 0
+fi
+
+# Run clang-format on the staged files.
+for file in $staged_files; do
+  if [[ "${file##*.}" == "h" || "${file##*.}" == "cpp" || "${file##*.}" == "hpp" || "${file##*.}" == "cc" ]]; then
+    clang-format -style=file -i "$file"
+    git add "$file"
+  fi
+done
+
+echo "All staged files formatted with clang-format."

--- a/tools/setup_hooks
+++ b/tools/setup_hooks
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+echo "Setting up Git hooks..."
+
+# Copy the pre-commit hook to the .git/hooks directory.
+cp tools/pre-commit .git/hooks/pre-commit
+
+# Make the pre-commit hook executable.
+chmod +x .git/hooks/pre-commit
+
+echo "Git hooks setup complete."


### PR DESCRIPTION
This PR closes [GV-6](https://graphviz.atlassian.net/browse/GV-6?atlOrigin=eyJpIjoiNWRkMTM5MDA4ZmNkNDE1OGFhMTNiNDY3Mjk0NDYyNGYiLCJwIjoiaiJ9) ticket.

Added pre-commit script in directory tools, which will copy in .git/hooks/ directory by using setup_hooks script, when library was ruined.
