### PR TITLE
GV-22. Create Graph::graphExport

### DIFF
--- a/examples/golden_graph/graph.cpp
+++ b/examples/golden_graph/graph.cpp
@@ -40,3 +40,40 @@ void Graph::addEdge(int id1, int id2)
 	}
 
 }
+
+static void Graph::graphExport(const Graph* graph) {
+	// create integer to hold index of graph
+	static int indexOfGraph = 1;
+	
+	// create the jsonGraph object
+	json jsonGraph;
+	jsonGraph["node"] = json::array();
+	const auto nodes = graph->getAllNodes();
+	for (const auto& node : nodes) {
+		jsonGraph["node"].push_back(node->getID());
+	}
+
+	// create jsonNode objects for the first graph
+	for (const auto& node : nodes) {
+		json jsonNode;
+		jsonNode["value"] = node->getValue();
+		jsonNode["neighbors"] = json::array();
+
+		// add each neighbor to the jsonNode object
+		const auto edges = node->getEdges();
+		for (const auto& edge : edges) {
+			jsonNode["neighbors"].push_back(edge->getDestinationID());
+		}
+		// add the jsonNode object to the graph object
+		jsonGraph[node->getID()] = jsonNode;
+	}
+
+	// Add name of graph. Example graph_1, graph_2, ...
+	jsonGraph["name"] = "graph_" + std::to_string(indexOfGraph);
+	++indexOfGraph;
+
+    // write the JSON object to a file
+    std::ofstream file("export.json", std::ios::app);
+    file << jsonGraph.dump(4); // pretty print with 4 spaces
+    file.close();
+}

--- a/examples/golden_graph/graph.hpp
+++ b/examples/golden_graph/graph.hpp
@@ -2,8 +2,12 @@
 #define EXAMPLES_GOLDEN_GRAPH_GRAPH_HPP
 
 #include "node.hpp"
+#include "edge.hpp"
+#include "../../libs/json/include/nlohmann/json.hpp"  // This relative path will be modified
 #include <iostream>
 #include <vector>
+
+using json = nlohmann::json;
 
 class Graph
 {
@@ -13,6 +17,7 @@ public:
     const Node* getNode(int id) const;
     const std::vector<Node*>& getAllNodes() const;
     void addEdge(int id1, int id2);
+    static void Graph::graphExport(const Graph* graph);
 private:
     bool m_checkID(int id);
 private:


### PR DESCRIPTION
This PR closes the [GV-22](https://graphviz.atlassian.net/browse/GV-22?atlOrigin=eyJpIjoiZjViZjQ5ZmY1NTViNDI0Yjk2ZDVhOTE1YWQyZWY0ZjMiLCJwIjoiaiJ9) ticket.

In the Graph::graphExport() method, we don't check if the `export.json` file is a valid json file because it is generated by us.

We don't test this method yet.
An example output of this method will be something like this:
`export.json`
"graph_1": {
    "node": [1, 2],
    "1": {
        "value": 1,
        "neighbors": [2]
    },
    "2": {
        "value": 2,
        "neighbors": [1]
    },
    "name": "graph_1"
}


