### PR TITLE
GV-40. Integrate Qt using CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,9 @@ cmake_minimum_required(VERSION 3.15)
 
 project(graphviz VERSION 0.0.1 LANGUAGES CXX)
 
+# Set prefix path for qt install folder
+set($(CMAKE_PREFIX_PATH))
+
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
@@ -22,6 +25,6 @@ target_include_directories(my_project_executable PRIVATE
     include
 )
 
-
 add_subdirectory(libs)
 add_subdirectory(tests)
+add_subdirectory(qt_part)

--- a/qt_part/.gitignore
+++ b/qt_part/.gitignore
@@ -1,0 +1,74 @@
+# This file is used to ignore files which are generated
+# ----------------------------------------------------------------------------
+
+*~
+*.autosave
+*.a
+*.core
+*.moc
+*.o
+*.obj
+*.orig
+*.rej
+*.so
+*.so.*
+*_pch.h.cpp
+*_resource.rc
+*.qm
+.#*
+*.*#
+core
+!core/
+tags
+.DS_Store
+.directory
+*.debug
+Makefile*
+*.prl
+*.app
+moc_*.cpp
+ui_*.h
+qrc_*.cpp
+Thumbs.db
+*.res
+*.rc
+/.qmake.cache
+/.qmake.stash
+
+# qtcreator generated files
+*.pro.user*
+CMakeLists.txt.user*
+
+# xemacs temporary files
+*.flc
+
+# Vim temporary files
+.*.swp
+
+# Visual Studio generated files
+*.ib_pdb_index
+*.idb
+*.ilk
+*.pdb
+*.sln
+*.suo
+*.vcproj
+*vcproj.*.*.user
+*.ncb
+*.sdf
+*.opensdf
+*.vcxproj
+*vcxproj.*
+
+# MinGW generated files
+*.Debug
+*.Release
+
+# Python byte code
+*.pyc
+
+# Binaries
+# --------
+*.dll
+*.exe
+

--- a/qt_part/CMakeLists.txt
+++ b/qt_part/CMakeLists.txt
@@ -1,0 +1,61 @@
+cmake_minimum_required(VERSION 3.5)
+
+project(qt_part VERSION 0.1 LANGUAGES CXX)
+
+set(CMAKE_AUTOUIC ON)
+set(CMAKE_AUTOMOC ON)
+set(CMAKE_AUTORCC ON)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+find_package(QT NAMES Qt6 Qt5 REQUIRED COMPONENTS Widgets)
+find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS Widgets)
+
+set(PROJECT_SOURCES
+        main.cpp
+        graphviz.cpp
+        graphviz.h
+        graphviz.ui
+)
+
+if(${QT_VERSION_MAJOR} GREATER_EQUAL 6)
+    qt_add_executable(qt_part
+        MANUAL_FINALIZATION
+        ${PROJECT_SOURCES}
+    )
+# Define target properties for Android with Qt 6 as:
+#    set_property(TARGET qt_part APPEND PROPERTY QT_ANDROID_PACKAGE_SOURCE_DIR
+#                 ${CMAKE_CURRENT_SOURCE_DIR}/android)
+# For more information, see https://doc.qt.io/qt-6/qt-add-executable.html#target-creation
+else()
+    if(ANDROID)
+        add_library(qt_part SHARED
+            ${PROJECT_SOURCES}
+        )
+# Define properties for Android with Qt 5 after find_package() calls as:
+#    set(ANDROID_PACKAGE_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/android")
+    else()
+        add_executable(qt_part
+            ${PROJECT_SOURCES}
+        )
+    endif()
+endif()
+
+target_link_libraries(qt_part PRIVATE Qt${QT_VERSION_MAJOR}::Widgets)
+
+set_target_properties(qt_part PROPERTIES
+    MACOSX_BUNDLE_GUI_IDENTIFIER my.example.com
+    MACOSX_BUNDLE_BUNDLE_VERSION ${PROJECT_VERSION}
+    MACOSX_BUNDLE_SHORT_VERSION_STRING ${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}
+    MACOSX_BUNDLE TRUE
+    WIN32_EXECUTABLE TRUE
+)
+
+install(TARGETS qt_part
+    BUNDLE DESTINATION .
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
+
+if(QT_VERSION_MAJOR EQUAL 6)
+    qt_finalize_executable(qt_part)
+endif()

--- a/qt_part/export.json
+++ b/qt_part/export.json
@@ -1,0 +1,36 @@
+{
+    "graph_1": {
+        "node": [1, 2, 3],
+        "1": {
+            "value": 5,
+            "neighbors": [2, 3]
+        },
+        "2": {
+            "value": 3,
+            "neighbors": [1, 3]
+        },
+        "3": {
+            "value": 8,
+            "neighbors": [1, 2]
+        },
+        "name": "Graph 1"
+    },
+    "graph_2": {
+        "node": [1, 2, 3],
+        "1": {
+            "value": 3,
+            "neighbors": [3]
+        },
+        "2": {
+            "value": 9,
+            "neighbors": [3]
+        },
+        "3": {
+            "value": 70,
+            "neighbors": [1, 2]
+        },
+        "name": "Graph 2"
+    }
+    
+}
+

--- a/qt_part/graphviz.cpp
+++ b/qt_part/graphviz.cpp
@@ -1,0 +1,15 @@
+#include "graphviz.h"
+#include "./ui_graphviz.h"
+
+GraphViz::GraphViz(QWidget *parent)
+    : QMainWindow(parent)
+    , ui(new Ui::GraphViz)
+{
+    ui->setupUi(this);
+}
+
+GraphViz::~GraphViz()
+{
+    delete ui;
+}
+

--- a/qt_part/graphviz.h
+++ b/qt_part/graphviz.h
@@ -1,0 +1,21 @@
+#ifndef GRAPHVIZ_H
+#define GRAPHVIZ_H
+
+#include <QMainWindow>
+
+QT_BEGIN_NAMESPACE
+namespace Ui { class GraphViz; }
+QT_END_NAMESPACE
+
+class GraphViz : public QMainWindow
+{
+    Q_OBJECT
+
+public:
+    GraphViz(QWidget *parent = nullptr);
+    ~GraphViz();
+
+private:
+    Ui::GraphViz *ui;
+};
+#endif // GRAPHVIZ_H

--- a/qt_part/graphviz.ui
+++ b/qt_part/graphviz.ui
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>GraphViz</class>
+ <widget class="QMainWindow" name="GraphViz">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>800</width>
+    <height>600</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>GraphViz</string>
+  </property>
+  <widget class="QWidget" name="centralwidget"/>
+  <widget class="QMenuBar" name="menubar"/>
+  <widget class="QStatusBar" name="statusbar"/>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/qt_part/main.cpp
+++ b/qt_part/main.cpp
@@ -1,0 +1,117 @@
+#include "graphviz.h"
+
+#include <QApplication>
+
+//int main(int argc, char *argv[])
+//{
+//    QApplication a(argc, argv);
+//    GraphViz w;
+//    w.show();
+//    return a.exec();
+//}
+
+#include <QGraphicsScene>
+#include <QGraphicsEllipseItem>
+#include <QGraphicsView>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QJsonArray>
+#include <QDebug>
+#include <QFile>
+
+int main(int argc, char *argv[])
+{
+    QApplication a(argc, argv);
+
+    // Read graph data from export.json
+    QFile file("export.json");
+    if (!file.open(QIODevice::ReadOnly | QIODevice::Text)) {
+        qDebug() << "Failed to open file";
+        return -1;
+    }
+    // Seed the random number generator
+    srand(11);
+
+    QJsonParseError jsonError;
+    QJsonDocument jsonDoc = QJsonDocument::fromJson(file.readAll(), &jsonError);
+    if (jsonError.error != QJsonParseError::NoError) {
+        qDebug() << "Failed to parse JSON:" << jsonError.errorString();
+        return -1;
+    }
+
+    QGraphicsScene scene;
+    QGraphicsView view(&scene);
+    view.setWindowTitle("GraphViz");
+    view.setRenderHint(QPainter::Antialiasing);
+    view.setDragMode(QGraphicsView::ScrollHandDrag);
+
+    // Parse graph data
+    QJsonObject graphObj = jsonDoc.object();
+
+    // Define variables for positioning the graphs
+    int cur_row = 0;
+    int cur_col = 0;
+
+    for (auto it = graphObj.begin(); it != graphObj.end(); ++it) {
+        QString graphName = it.key();
+        QJsonObject graphData = it.value().toObject();
+
+        QJsonArray nodeArray = graphData["node"].toArray();
+        QMap<int, QPointF> nodeMap;
+
+
+        // Add nodes to the scene
+        for (auto nodeIt = nodeArray.begin(); nodeIt != nodeArray.end(); ++nodeIt) {
+            int nodeId = nodeIt->toInt();
+            QJsonObject nodeObj = graphData[QString::number(nodeId)].toObject();
+            int nodeValue = nodeObj["value"].toInt();
+
+//            QPointF pos(rand() % 800, rand() % 800);
+
+            // Calculate the position of the node based on its column and row
+            QPointF pos(cur_col + rand()%100, cur_row + rand()%50);
+            cur_col += 100;
+            cur_row += 50;
+            nodeMap[nodeId] = pos;
+            QGraphicsEllipseItem* nodeItem = new QGraphicsEllipseItem(QRectF(-15, -15, 20, 20));
+            nodeItem->setPos(pos);
+            nodeItem->setBrush(Qt::black);
+
+            // Create a text item to show the node's id and value
+            QGraphicsTextItem* textItem = new QGraphicsTextItem(QString("id: %1\nvalue: %2").arg(nodeId).arg(nodeValue));
+            textItem->setPos(pos + QPointF(-10, -25)); // Position the text above the node
+            textItem->setDefaultTextColor(Qt::white);
+
+            // Add the text item to the node's parent item
+            QGraphicsItemGroup* groupItem = new QGraphicsItemGroup();
+            groupItem->addToGroup(nodeItem);
+            groupItem->addToGroup(textItem);
+            scene.addItem(groupItem);
+        }
+
+        // Add graph name to the scene
+        QGraphicsTextItem* graphNameItem = new QGraphicsTextItem(graphName);
+        graphNameItem->setPos(nodeMap.first() + QPointF(-50, -50));
+        scene.addItem(graphNameItem);
+
+        // Add edges to the scene
+        for (auto nodeIt = nodeArray.begin(); nodeIt != nodeArray.end(); ++nodeIt) {
+            int srcNodeId = nodeIt->toInt();
+            QJsonObject srcNodeObj = graphData[QString::number(srcNodeId)].toObject();
+            QJsonArray neighborArray = srcNodeObj["neighbors"].toArray();
+
+            for (auto neighborIt = neighborArray.begin(); neighborIt != neighborArray.end(); ++neighborIt) {
+                int destNodeId = neighborIt->toInt();
+                QGraphicsLineItem* edgeItem = new QGraphicsLineItem(QLineF(nodeMap[srcNodeId], nodeMap[destNodeId]));
+                edgeItem->setPen(QPen(Qt::red));
+                scene.addItem(edgeItem);
+            }
+        }
+    }
+
+    view.fitInView(scene.sceneRect(), Qt::KeepAspectRatio);
+    view.show();
+
+    return a.exec();
+}
+


### PR DESCRIPTION
This PR closes [GV-40](https://graphviz.atlassian.net/browse/GV-40?atlOrigin=eyJpIjoiNzE1ODVkYTU1OTUxNDU3OTgxY2MxYjE4YTg2YjFhMDAiLCJwIjoiaiJ9) ticket.

Added in CmakeLists.txt file these rows:
**set($(CMAKE_PREFIX_PATH))** -> This command set the path to Qt install folder.
**add_subdirectory(qt_part)**          -> This command adds a subdirectory to build it also.

The build command switch to this to add the path to Qt installation folder In your system (you have to change the path with your actual path)
**cmake -S . -B build -DCMAKE_PREFIX_PATH=/path/to/Qt/6.4.2/gcc_64/lib/cmake**

